### PR TITLE
Require at least slack-client 1.3.1 to use postMessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "test": "mocha --compilers coffee:coffee-script/register --reporter spec"
   },
   "dependencies": {
-    "slack-client": "~1.2.0"
+    "slack-client": "~1.3.1"
   }
 }


### PR DESCRIPTION
Your pull review lacks a bump in the slack-client dependency, because you depend on `channel.postMessage`, which is already merged upstream in version `1.3.1`.